### PR TITLE
feat(automations): allow specifying timing contraints on a trigger

### DIFF
--- a/test/commands/automations.test.ts
+++ b/test/commands/automations.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-nested-callbacks */
 import { expect, test } from '@oclif/test'
+import { exit } from 'process'
 import { MailscriptApiServer } from './constants'
 
 describe('Automations', () => {
@@ -44,10 +45,12 @@ describe('Automations', () => {
             {
               id: 'access-01-xxx-yyy-zzz',
               name: 'test@mailscript.io',
+              type: 'mailscript-email',
             },
             {
               id: 'webhook-xyz',
               name: 'webhook',
+              type: 'mailscript-email',
             },
             {
               id: 'access-03-xxx-yyy-zzz',
@@ -68,10 +71,13 @@ describe('Automations', () => {
             {
               id: 'access-01-xxx-yyy-zzz',
               name: 'test@mailscript.io',
+              type: 'mailscript-email',
+              address: 'test@mailscript.io',
             },
             {
               id: 'webhook-xyz',
               name: 'webhook',
+              type: 'mailscript-email',
             },
             {
               id: 'access-03-xxx-yyy-zzz',
@@ -90,213 +96,289 @@ describe('Automations', () => {
         .reply(201, { id: 'auto-xxx-yyy-zzz' })
     }
 
-    describe('forward', () => {
-      test
-        .stdout()
-        .nock(MailscriptApiServer, nockAdd)
-        .command([
-          'automations',
-          'add',
-          '--trigger',
-          'test@mailscript.io',
-          '--action',
-          'test@mailscript.io',
-          '--forward',
-          'another@example.com',
-        ])
-        .it('add forward automation', (ctx) => {
-          expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
-          expect(postBody.actions[0].config).to.eql({
-            type: 'forward',
-            forward: 'another@example.com',
-          })
-        })
-
-      test
-        .stdout()
-        .nock(MailscriptApiServer, nockAdd)
-        .command([
-          'automations',
-          'add',
-          '--trigger',
-          'test@mailscript.io',
-          '--forward',
-          'another@example.com',
-        ])
-        .it('defaults action to trigger if none provided', (ctx) => {
-          expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
-        })
-    })
-
-    describe('send', () => {
-      test
-        .stdout()
-        .nock(MailscriptApiServer, nockAdd)
-        .command([
-          'automations',
-          'add',
-          '--trigger',
-          'test@mailscript.io',
-          '--send',
-          'another@example.com',
-          '--subject',
-          'subject',
-          '--text',
-          'text',
-        ])
-        .it('add send automation', (ctx) => {
-          expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
-          expect(postBody.actions[0].config).to.eql({
-            subject: 'subject',
-            text: 'text',
-            to: 'another@example.com',
-            type: 'send',
-          })
-        })
-    })
-
-    describe('reply', () => {
-      test
-        .stdout()
-        .nock(MailscriptApiServer, nockAdd)
-        .command([
-          'automations',
-          'add',
-          '--trigger',
-          'test@mailscript.io',
-          '--reply',
-          '--text',
-          'text',
-        ])
-        .it('add reply automation', (ctx) => {
-          expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
-          expect(postBody.actions[0].config).to.eql({
-            type: 'reply',
-            text: 'text',
-          })
-        })
-    })
-
-    describe('reply all', () => {
-      test
-        .stdout()
-        .nock(MailscriptApiServer, nockAdd)
-        .command([
-          'automations',
-          'add',
-          '--trigger',
-          'test@mailscript.io',
-          '--replyall',
-          '--text',
-          'text',
-        ])
-        .it('add reply all automation', (ctx) => {
-          expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
-          expect(postBody.actions[0].config).to.eql({
-            type: 'replyAll',
-            text: 'text',
-          })
-        })
-    })
-
-    describe('alias', () => {
-      test
-        .stdout()
-        .nock(MailscriptApiServer, nockAdd)
-        .command([
-          'automations',
-          'add',
-          '--trigger',
-          'test@mailscript.io',
-          '--alias',
-          'another@mailscript.io',
-          '--text',
-          'text',
-        ])
-        .it('add reply all automation', (ctx) => {
-          expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
-          expect(postBody.actions[0].config).to.eql({
-            type: 'alias',
-            alias: 'another@mailscript.io',
-          })
-        })
-    })
-
-    describe('webhook', () => {
-      test
-        .stdout()
-        .nock(MailscriptApiServer, nockAdd)
-        .command([
-          'automations',
-          'add',
-          '--trigger',
-          'test@mailscript.io',
-          '--webhook',
-          'http://example.com/webhook',
-        ])
-        .it('add webhook automation', (ctx) => {
-          expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
-          expect(postBody.actions[0].accessoryId.startsWith('webhook-'))
-          expect(postBody.actions[0].config).to.eql({
-            type: 'webhook',
-            url: 'http://example.com/webhook',
-            opts: {
-              headers: {
-                'Content-Type': 'application/json',
+    describe('triggers', () => {
+      describe('time based', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--forward',
+            'another@example.com',
+            '--times',
+            '5',
+            '--seconds',
+            '50',
+          ])
+          .it('adds automation on the server', (ctx) => {
+            expect(ctx.stdout).to.contain('Automation setup: auto-xxx-yyy-zzz')
+            expect(postBody.trigger.config).to.eql({
+              criterias: [
+                {
+                  sentTo: 'test@mailscript.io',
+                },
+              ],
+              times: {
+                thisManySeconds: 50,
+                thisManyTimes: 5,
               },
-              method: 'POST',
-            },
-            body: '',
+            })
           })
-        })
+
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockRead)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--forward',
+            'another@example.com',
+            '--times',
+            '5',
+          ])
+          .exit(1)
+          .it('errors if times proved but not seconds', (ctx) => {
+            expect(ctx.stdout).to.contain(
+              'Flag --seconds required when using --times',
+            )
+          })
+
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockRead)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--forward',
+            'another@example.com',
+            '--seconds',
+            '120',
+          ])
+          .exit(1)
+          .it('errors if seconds provided but not times', (ctx) => {
+            expect(ctx.stdout).to.contain(
+              'Flag --times required when using --seconds',
+            )
+          })
+      })
     })
 
-    describe('sms', () => {
-      test
-        .stdout()
-        .nock(MailscriptApiServer, nockAdd)
-        .command([
-          'automations',
-          'add',
-          '--trigger',
-          'test@mailscript.io',
-          '--action',
-          'test-sms',
-          '--text',
-          'from mailscript - {{subject}}',
-        ])
-        .it('add sms automation', (ctx) => {
-          expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
-          expect(postBody.actions[0].accessoryId).to.eql(
-            'access-03-xxx-yyy-zzz',
-          )
-          expect(postBody.actions[0].config).to.eql({
-            type: 'sms',
-            text: 'from mailscript - {{subject}}',
+    describe('types', () => {
+      describe('forward', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--action',
+            'test@mailscript.io',
+            '--forward',
+            'another@example.com',
+          ])
+          .it('add forward automation', (ctx) => {
+            expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
+            expect(postBody.actions[0].config).to.eql({
+              type: 'forward',
+              forward: 'another@example.com',
+            })
           })
-        })
-    })
 
-    describe('multiple types', () => {
-      test
-        .stdout()
-        .nock(MailscriptApiServer, nockRead)
-        .command([
-          'automations',
-          'add',
-          '--trigger',
-          'test@mailscript.io',
-          '--alias',
-          'another@mailscript.io',
-          '--send',
-          'another@mailscript.io',
-          '--text',
-          'text',
-        ])
-        .exit(1)
-        .it('it errors', (ctx) => {
-          expect(ctx.stdout).to.contain('Please provide one type flag either')
-        })
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--forward',
+            'another@example.com',
+          ])
+          .it('defaults action to trigger if none provided', (ctx) => {
+            expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
+          })
+      })
+
+      describe('send', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--send',
+            'another@example.com',
+            '--subject',
+            'subject',
+            '--text',
+            'text',
+          ])
+          .it('add send automation', (ctx) => {
+            expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
+            expect(postBody.actions[0].config).to.eql({
+              subject: 'subject',
+              text: 'text',
+              to: 'another@example.com',
+              type: 'send',
+            })
+          })
+      })
+
+      describe('reply', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--reply',
+            '--text',
+            'text',
+          ])
+          .it('add reply automation', (ctx) => {
+            expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
+            expect(postBody.actions[0].config).to.eql({
+              type: 'reply',
+              text: 'text',
+            })
+          })
+      })
+
+      describe('reply all', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--replyall',
+            '--text',
+            'text',
+          ])
+          .it('add reply all automation', (ctx) => {
+            expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
+            expect(postBody.actions[0].config).to.eql({
+              type: 'replyAll',
+              text: 'text',
+            })
+          })
+      })
+
+      describe('alias', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--alias',
+            'another@mailscript.io',
+            '--text',
+            'text',
+          ])
+          .it('add reply all automation', (ctx) => {
+            expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
+            expect(postBody.actions[0].config).to.eql({
+              type: 'alias',
+              alias: 'another@mailscript.io',
+            })
+          })
+      })
+
+      describe('webhook', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--webhook',
+            'http://example.com/webhook',
+          ])
+          .it('add webhook automation', (ctx) => {
+            expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
+            expect(postBody.actions[0].accessoryId.startsWith('webhook-'))
+            expect(postBody.actions[0].config).to.eql({
+              type: 'webhook',
+              url: 'http://example.com/webhook',
+              opts: {
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                method: 'POST',
+              },
+              body: '',
+            })
+          })
+      })
+
+      describe('sms', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--action',
+            'test-sms',
+            '--text',
+            'from mailscript - {{subject}}',
+          ])
+          .it('add sms automation', (ctx) => {
+            expect(ctx.stdout).to.contain('auto-xxx-yyy-zzz')
+            expect(postBody.actions[0].accessoryId).to.eql(
+              'access-03-xxx-yyy-zzz',
+            )
+            expect(postBody.actions[0].config).to.eql({
+              type: 'sms',
+              text: 'from mailscript - {{subject}}',
+            })
+          })
+      })
+
+      describe('multiple types', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockRead)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--alias',
+            'another@mailscript.io',
+            '--send',
+            'another@mailscript.io',
+            '--text',
+            'text',
+          ])
+          .exit(1)
+          .it('it errors', (ctx) => {
+            expect(ctx.stdout).to.contain('Please provide one type flag either')
+          })
+      })
     })
   })
 })


### PR DESCRIPTION
Include `--times` and `--seconds` in the `mailscript automations add` command. Both must be
integers.

Part of (trello card)[https://trello.com/c/iRclnWoS]