### PR TITLE
feat(automations): complex contraints when adding an automation

### DIFF
--- a/src/commands/automations.ts
+++ b/src/commands/automations.ts
@@ -86,9 +86,6 @@ export default class Automations extends Command {
     from: flags.string({
       description: 'constrain trigger to emails from the specified address',
     }),
-    sentto: flags.string({
-      description: 'constrain trigger to emails sent to the specified address',
-    }),
     subjectcontains: flags.string({
       description:
         'constrain trigger to emails whose subject contains the specified text',
@@ -224,7 +221,6 @@ export default class Automations extends Command {
     let criterias: Array<any> = []
     if (
       flags.from ||
-      flags.sentto ||
       flags.hasthewords ||
       flags.domain ||
       flags.subjectcontains ||
@@ -233,7 +229,6 @@ export default class Automations extends Command {
       criterias = [
         {
           from: flags.from,
-          sentTo: flags.sentto,
           hasTheWords: flags.hasthewords,
           domain: flags.domain,
           subjectContains: flags.subjectcontains,

--- a/test/commands/automations.test.ts
+++ b/test/commands/automations.test.ts
@@ -195,32 +195,6 @@ describe('Automations', () => {
           })
       })
 
-      describe('sentTo', () => {
-        test
-          .stdout()
-          .nock(MailscriptApiServer, nockAdd)
-          .command([
-            'automations',
-            'add',
-            '--trigger',
-            'test@mailscript.io',
-            '--forward',
-            'another@example.com',
-            '--sentto',
-            'test+spam@mailscript.io',
-          ])
-          .it('adds automation on the server', (ctx) => {
-            expect(ctx.stdout).to.contain('Automation setup: auto-xxx-yyy-zzz')
-            expect(postBody.trigger.config).to.eql({
-              criterias: [
-                {
-                  sentTo: 'test+spam@mailscript.io',
-                },
-              ],
-            })
-          })
-      })
-
       describe('subjectContains', () => {
         test
           .stdout()
@@ -337,8 +311,6 @@ describe('Automations', () => {
             'another@example.com',
             '--from',
             'smith@example.com',
-            '--sentto',
-            'test@mailscript.io',
             '--subjectcontains',
             'a subject',
             '--domain',
@@ -356,7 +328,6 @@ describe('Automations', () => {
                   from: 'smith@example.com',
                   hasAttachments: true,
                   hasTheWords: 'alert',
-                  sentTo: 'test@mailscript.io',
                   subjectContains: 'a subject',
                 },
               ],


### PR DESCRIPTION
Accepts `--domain`, `--from`, `--sentto`, `--hasattachments`, `hasthewords`, `--subjectcontains`.

Part of (trello card)[https://trello.com/c/iRclnWoS]