### PR TITLE
feat(automations): allow `sentto` as a criteria

### DIFF
--- a/src/commands/automations.ts
+++ b/src/commands/automations.ts
@@ -86,6 +86,9 @@ export default class Automations extends Command {
     from: flags.string({
       description: 'constrain trigger to emails from the specified address',
     }),
+    sentto: flags.string({
+      description: 'constrain trigger to emails sent to the specified address',
+    }),
     subjectcontains: flags.string({
       description:
         'constrain trigger to emails whose subject contains the specified text',
@@ -222,6 +225,7 @@ export default class Automations extends Command {
     let criterias: Array<any> = []
     if (
       flags.from ||
+      flags.sentto ||
       flags.hasthewords ||
       flags.domain ||
       flags.subjectcontains ||
@@ -230,6 +234,7 @@ export default class Automations extends Command {
       criterias = [
         {
           from: flags.from,
+          sentTo: flags.sentto,
           hasTheWords: flags.hasthewords,
           domain: flags.domain,
           subjectContains: flags.subjectcontains,

--- a/test/commands/automations.test.ts
+++ b/test/commands/automations.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-nested-callbacks */
 import { expect, test } from '@oclif/test'
-import { exit } from 'process'
 import { MailscriptApiServer } from './constants'
 
 describe('Automations', () => {
@@ -199,6 +198,32 @@ describe('Automations', () => {
               criterias: [
                 {
                   from: 'smith@example.com',
+                },
+              ],
+            })
+          })
+      })
+
+      describe('sentto', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'automations',
+            'add',
+            '--trigger',
+            'test@mailscript.io',
+            '--forward',
+            'another@example.com',
+            '--sentto',
+            'test+spam@mailscript.io',
+          ])
+          .it('adds automation on the server', (ctx) => {
+            expect(ctx.stdout).to.contain('Automation setup: auto-xxx-yyy-zzz')
+            expect(postBody.trigger.config).to.eql({
+              criterias: [
+                {
+                  sentTo: 'test+spam@mailscript.io',
                 },
               ],
             })


### PR DESCRIPTION
When adding an automation and include the flag `--sentto`.