### PR TITLE
feat(workflows): set criterias as empty if none are provided

### DIFF
--- a/src/commands/workflows.ts
+++ b/src/commands/workflows.ts
@@ -281,11 +281,7 @@ export default class Workflows extends Command {
         },
       ]
     } else if (triggerAccessory.type === 'mailscript-email') {
-      criterias = [
-        {
-          sentTo: triggerAccessory.address,
-        },
-      ]
+      criterias = []
     }
 
     return flags.times && flags.seconds

--- a/test/commands/workflows.test.ts
+++ b/test/commands/workflows.test.ts
@@ -137,11 +137,7 @@ describe('workflows', () => {
           .it('adds workflow on the server', (ctx) => {
             expect(ctx.stdout).to.contain('Workflow setup: auto-xxx-yyy-zzz')
             expect(postBody.trigger.config).to.eql({
-              criterias: [
-                {
-                  sentTo: 'test@mailscript.io',
-                },
-              ],
+              criterias: [],
               times: {
                 thisManySeconds: 50,
                 thisManyTimes: 5,


### PR DESCRIPTION
This changes the previous behaviour of setting `sentTo`. The pipeline assumes a new constraint of
derived address, and rather than try and expose that concept to the user we are showing no criteria
and leaving the constraint on the address implied.

Part of this (trello card)[https://trello.com/c/w94SfeWT]