### PR TITLE
feat(workflows): allow `firstTimeSender` criteria when adding a workflow

### DIFF
--- a/src/commands/workflows/add.ts
+++ b/src/commands/workflows/add.ts
@@ -144,6 +144,10 @@ export default class WorkflowsAdd extends Command {
     hasattachments: flags.boolean({
       description: 'constrain trigger to emails with attachments',
     }),
+    firsttimesender: flags.boolean({
+      description:
+        'constrain trigger to emails that are the first seen from the sending address',
+    }),
   }
 
   static args = []
@@ -251,7 +255,8 @@ export default class WorkflowsAdd extends Command {
       flags.hasthewords ||
       flags.domain ||
       flags.subjectcontains ||
-      flags.hasattachments
+      flags.hasattachments ||
+      flags.firsttimesender
     ) {
       criterias = [
         {
@@ -261,6 +266,7 @@ export default class WorkflowsAdd extends Command {
           domain: flags.domain,
           subjectContains: flags.subjectcontains,
           hasAttachments: flags.hasattachments,
+          firstTimeSender: flags.firsttimesender,
         },
       ]
     } else if (triggerAccessory.type === 'mailscript-email') {

--- a/test/commands/workflows.test.ts
+++ b/test/commands/workflows.test.ts
@@ -447,6 +447,32 @@ describe('workflows', () => {
           })
       })
 
+      describe('firstTimeSender', () => {
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAdd)
+          .command([
+            'workflows:add',
+            '--name',
+            'work-01',
+            '--trigger',
+            'test@mailscript.io',
+            '--forward',
+            'another@example.com',
+            '--firsttimesender',
+          ])
+          .it('adds workflow on the server', (ctx) => {
+            expect(ctx.stdout).to.contain('Workflow setup: work-01')
+            expect(postBody.trigger.config).to.eql({
+              criterias: [
+                {
+                  firstTimeSender: true,
+                },
+              ],
+            })
+          })
+      })
+
       describe('all', () => {
         test
           .stdout()
@@ -470,6 +496,7 @@ describe('workflows', () => {
             '--hasthewords',
             'alert',
             '--hasattachments',
+            '--firsttimesender',
           ])
           .it('adds workflow on the server', (ctx) => {
             expect(ctx.stdout).to.contain('Workflow setup: work-01')
@@ -482,6 +509,7 @@ describe('workflows', () => {
                   hasAttachments: true,
                   hasTheWords: 'alert',
                   subjectContains: 'a subject',
+                  firstTimeSender: true,
                 },
               ],
             })


### PR DESCRIPTION
The `mailscript workflows:add` command now has an additional boolean flag `--firsttimesender`

## Trello

Part of the [card](https://trello.com/c/smmbIveZ)