### PR TITLE
feat(workflows): support adding with alias to user control addresses

### DIFF
--- a/src/commands/workflows/add.ts
+++ b/src/commands/workflows/add.ts
@@ -457,6 +457,32 @@ export default class WorkflowsAdd extends Command {
       return
     }
 
+    const {
+      list: userAccessories,
+    }: api.GetAllAccessoriesResponse = await handle(
+      client.getAllAccessories(),
+      withStandardErrors({}, this),
+    )
+
+    const existingAccessory = userAccessories.find(
+      ({ name, type }) => type === 'mailscript-email' && name === alias,
+    )
+
+    if (existingAccessory) {
+      this.log('Checking existing mailscript address')
+
+      if (existingAccessory.address) {
+        const { write } = await handle(
+          client.getKey(existingAccessory.address, existingAccessory.key),
+          withStandardErrors({}, this),
+        )
+
+        if (write) {
+          return
+        }
+      }
+    }
+
     const { list: verifications } = await handle(
       client.getAllVerifications(),
       withStandardErrors({}, this),

--- a/src/commands/workflows/add.ts
+++ b/src/commands/workflows/add.ts
@@ -7,6 +7,7 @@ import { handle } from 'oazapfts'
 import * as api from '../../api'
 import setupApiClient from '../../setupApiClient'
 import withStandardErrors from '../../utils/errorHandling'
+import resolveBaseAddress from '../../utils/resolveBaseAddress'
 import verifyEmailFlow from '../../utils/verifyEmailFlow'
 
 const workflowTypeFlags = [
@@ -464,12 +465,16 @@ export default class WorkflowsAdd extends Command {
       withStandardErrors({}, this),
     )
 
+    const baseAlias = resolveBaseAddress(alias)
+
     const existingAccessory = userAccessories.find(
-      ({ name, type }) => type === 'mailscript-email' && name === alias,
+      ({ name, type }) => type === 'mailscript-email' && name === baseAlias,
     )
 
     if (existingAccessory) {
-      this.log('Checking existing mailscript address')
+      this.debug(
+        `Checking existing mailscript address: ${existingAccessory.address}`,
+      )
 
       if (existingAccessory.address) {
         const { write } = await handle(

--- a/src/utils/resolveBaseAddress.ts
+++ b/src/utils/resolveBaseAddress.ts
@@ -1,0 +1,121 @@
+const acceptedDomains = [
+  process.env.MAILSCRIPT_EMAIL_DOMAIN || 'mailscript.com',
+]
+
+function parseIntoParts(address: string) {
+  if (!address) {
+    return { parsed: false, error: 'No address provided' }
+  }
+
+  if (!address.includes('@')) {
+    return { parsed: false, error: 'Email address must include @' }
+  }
+
+  const parts = address.split('@')
+
+  if (parts.length > 2) {
+    return { parsed: false, error: 'Not a correctly formatted email address' }
+  }
+
+  const localPart = parts[0]
+  const domainPart = parts[1]
+
+  const domainSubparts = domainPart.split('.')
+
+  if (domainSubparts.length === 1 || domainSubparts.length > 3) {
+    return { parsed: false, error: 'Not a correctly formatted domain' }
+  }
+
+  if (domainSubparts.length === 2) {
+    if (!acceptedDomains.includes(domainPart)) {
+      return { parsed: false, error: 'Not an allowed domain' }
+    }
+
+    return {
+      parsed: true,
+      localPart,
+      subdomain: null,
+      domain: domainPart,
+    }
+  }
+
+  const subdomain = domainSubparts[0]
+  const domain = `${domainSubparts[1]}.${domainSubparts[2]}`
+  if (!acceptedDomains.includes(domain)) {
+    return { parsed: false, error: 'Not an allowed domain' }
+  }
+
+  return {
+    parsed: true,
+    localPart,
+    subdomain,
+    domain,
+  }
+}
+
+function replaceDotsAndDashes(text: string) {
+  return text ? text.replace(/\./g, '').replace(/-/g, '') : text
+}
+
+function removeAfterPlus(text: string) {
+  return text ? text.split('+')[0] : text
+}
+
+function substituteLocalPart(localPart: string) {
+  return removeAfterPlus(replaceDotsAndDashes(localPart))
+}
+
+function substituteDomain(localPart: string) {
+  return replaceDotsAndDashes(localPart)
+}
+
+function checkLocalPartCharacters(text: string) {
+  return /^[a-zA-Z0-9\-.+]+$/.test(text)
+}
+
+function checkCharacters(text: string) {
+  return /^[a-zA-Z0-9\-.]+$/.test(text)
+}
+
+function checkOnlyOnePlusSection(text: string) {
+  return /^[a-zA-Z0-9\-.]+(\+[a-zA-Z0-9\-.]+)?$/.test(text)
+}
+
+export default function resolveBaseAddress(address: string) {
+  if (!address) {
+    throw new Error('No address provided')
+  }
+
+  const sanitized = address.toLowerCase().trim()
+
+  if (!acceptedDomains.some((ad) => address.endsWith(ad))) {
+    return address
+  }
+
+  const result = parseIntoParts(sanitized)
+
+  const { parsed, error } = result
+
+  if (!parsed) {
+    throw new Error(error)
+  }
+
+  const { localPart, subdomain, domain } = result
+
+  if (!checkLocalPartCharacters(localPart!) || !checkCharacters(subdomain!)) {
+    throw new Error('Only letters and numbers allowed as characters')
+  }
+
+  if (!checkOnlyOnePlusSection(localPart!)) {
+    throw new Error('Only one plus in local part' + localPart)
+  }
+
+  const updatedlocalPart = substituteLocalPart(localPart!)
+  const updatedSubdomain = substituteDomain(subdomain!)
+
+  if (!subdomain) {
+    return `${updatedlocalPart}@${domain}`
+  }
+
+  return `${updatedlocalPart}@${updatedSubdomain}.${domain}`
+}

--- a/test/commands/workflows.test.ts
+++ b/test/commands/workflows.test.ts
@@ -731,12 +731,37 @@ describe('workflows', () => {
             'text',
           ])
           .it(
-            'add alias workflow if email write is user owned mailscript address',
+            'add alias workflow if email is user owned mailscript address',
             (ctx) => {
               expect(ctx.stdout).to.contain('work-01')
               expect(postBody.actions[0].config).to.eql({
                 type: 'alias',
                 alias: 'xyz@mailscript.io',
+              })
+            },
+          )
+
+        test
+          .stdout()
+          .nock(MailscriptApiServer, nockAddMailscriptAddress)
+          .command([
+            'workflows:add',
+            '--name',
+            'work-01',
+            '--trigger',
+            'test@mailscript.io',
+            '--alias',
+            'xyz+123@mailscript.io',
+            '--text',
+            'text',
+          ])
+          .it(
+            'add alias workflow if variant of email is user owned mailscript address',
+            (ctx) => {
+              expect(ctx.stdout).to.contain('work-01')
+              expect(postBody.actions[0].config).to.eql({
+                type: 'alias',
+                alias: 'xyz+123@mailscript.io',
               })
             },
           )


### PR DESCRIPTION
The user controls the mailscript address if the user has an accessory for that address that
references a key with write access.